### PR TITLE
A couple of bug fixes

### DIFF
--- a/packages/fixmyjs/fixmyjs.js
+++ b/packages/fixmyjs/fixmyjs.js
@@ -4676,7 +4676,8 @@ if (typeof exports === 'object' && exports)
 //
 // `parseInt(0420)` -> `parseInt(0420, 10)`
       radix: function (str) {
-        var rx = /parseInt\((.*)\)/;
+		//@todo: Do proper parenthesis parsing
+        var rx = /parseInt\(([^\)]+)\)/;
         var exec;
 
         if (rx.test(str)) {

--- a/packages/fixmyjs/fixmyjs.js
+++ b/packages/fixmyjs/fixmyjs.js
@@ -4558,7 +4558,7 @@ if (typeof exports === 'object' && exports)
 //
 // `.5` -> `0.5`
       leadingDecimal: function (str) {
-        var rx = /([\D])(\.[0-9]*)/;
+        var rx = /([\D])(\.[0-9]+)/;
 
         var result;
 
@@ -4740,7 +4740,7 @@ if (typeof exports === 'object' && exports)
 //
 // `12.` -> `12`
       trailingDecimal: function (str) {
-        var rx = /([0-9]*)\.(\D)/;
+        var rx = /([0-9]+)\.(\D)/;
         var result;
 
         if (rx.test(str)) {


### PR DESCRIPTION
Old revision:

var bug = new some.test(.2); -> var bug = new some0.test(.2);

var bug = someFunction(parseInt("0")); -> var bug = someFunction(parseInt("0"), 10);

some.bug = 2.; -> somebug = 2.;

This revision:

var bug = new some.test(.2); -> var bug = new some.test(0.2);

var bug = someFunction(parseInt("0")); -> var bug = someFunction(parseInt("0", 10));

some.bug = 2.; -> some.bug = 2;
